### PR TITLE
Enabled goPath to be set via config

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -162,7 +162,6 @@ class Locator {
 
     // Enables goPath to be set via config
     if (isTruthy(cfgGoPath)) {
-      console.log("get from conf")
       return cfgGoPath
     }
 

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -158,6 +158,14 @@ class Locator {
   // Returns the GOPATH if it exists, or false if it is not defined.
   gopath (options = {}) {
     let e = this.rawEnvironment(options)
+    let cfgGoPath = atom.config.get('go-config.goPath')
+
+    // Enables goPath to be set via config
+    if (isTruthy(cfgGoPath)) {
+      console.log("get from conf")
+      return cfgGoPath
+    }
+
     if (isFalsy(e.GOPATH) || e.GOPATH.trim() === '') {
       return false
     }


### PR DESCRIPTION
This PR will enable GOPATH to be set using the atom config.

This solves the following problems:
* Per project GOPATH using [atom-project-manager](https://github.com/danielbrodin/atom-project-manager) package.
* Because the GOPATH can be explicitly set, [GB](https://getgb.io/) (and similar) project structures, where the vendor folder exists outside the GOPATH and the source folder, now works.


