### PR TITLE
adding path to search for gocode and gometalinter

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -429,7 +429,9 @@ class Locator {
     // Built-In Tools
     this.toolStrategies.set('go', 'GOROOTBIN')
     this.toolStrategies.set('gofmt', 'GOROOTBIN')
+    this.toolStrategies.set('gocode', 'GOROOTBIN')
     this.toolStrategies.set('godoc', 'GOROOTBIN')
+    this.toolStrategies.set('gometalinter', 'GOROOTBIN')
     this.toolStrategies.set('addr2line', 'GOTOOLDIR')
     this.toolStrategies.set('api', 'GOTOOLDIR')
     this.toolStrategies.set('asm', 'GOTOOLDIR')


### PR DESCRIPTION
gocode and gometalinter are part of golang distribution (at least on Windows). Go get wasn't able to fetch packages properly and autocompletion wasn't working because of that. I had same problem on linux as well, but now i don't have acces to machine to verify this fix there. For windows it seems to be OK.