### PR TITLE
Add Ability To Configure GOPATH In Atom Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@
 
 This package provides an API via an Atom service. This API can be used by other packages that need to work with the `go` tool, other related tools (e.g. `gofmt`, `vet`, etc.) or `$GOPATH/bin` tools (e.g. `goimports`, `goreturns`, etc.).
 
-This package needs the [environment](https://atom.io/packages/environment) package installed to function correctly in all circumstances. If [environment](https://atom.io/packages/environment) is not installed, you may experience issues on OS X on versions of Atom < 1.7.0. You can safely uninstall environment for versions of Atom >= 1.7.0.
+## Configuration
+
+You can configure the GOPATH in the `go-config` package settings, however _it is not recommended_ to configure the package in this way. Please see https://github.com/joefitzgerald/go-config/wiki/GOPATH for further information.

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -157,12 +157,26 @@ class Locator {
   // Public: Get the gopath.
   // Returns the GOPATH if it exists, or false if it is not defined.
   gopath (options = {}) {
+    // Preferred: The Environment
     let e = this.rawEnvironment(options)
-    if (isFalsy(e.GOPATH) || e.GOPATH.trim() === '') {
-      return false
+    let g = e.GOPATH
+    if (isTruthy(g) && g.trim() !== '') {
+      return pathhelper.expand(e, g)
     }
 
-    return pathhelper.expand(e, e.GOPATH)
+    // Fallback: Atom Config
+    g = atom.config.get('go-config.gopath')
+    if (isTruthy(g) && g.trim() !== '') {
+      return pathhelper.expand(e, g)
+    }
+
+    // Fallback: Legacy go-plus Config
+    g = atom.config.get('go-plus.gopath')
+    if (isTruthy(g) && g.trim() !== '') {
+      return pathhelper.expand(e, g)
+    }
+
+    return false
   }
 
   // Public: Find the specified tool.

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,6 @@ import {Executor} from './executor'
 import semver from 'semver'
 
 export default {
-  environment: null,
   locator: null,
   subscriptions: null,
   dependenciesInstalled: null,
@@ -34,7 +33,6 @@ export default {
       this.subscriptions.dispose()
     }
     this.subscriptions = null
-    this.environment = null
     this.locator = null
     this.dependenciesInstalled = null
   },
@@ -62,27 +60,11 @@ export default {
     if (isFalsy(this.dependenciesInstalled)) {
       return false
     }
-    if (semver.satisfies(this.version(), '>=1.7.0')) {
-      return true
-    } else {
-      if (isTruthy(this.environment)) {
-        return true
-      } else {
-        return false
-      }
-    }
+    return true
   },
 
   getEnvironment () {
-    if (semver.satisfies(this.version(), '>=1.7.0')) {
-      return process.env
-    }
-
-    if (this.ready()) {
-      return this.environment
-    }
-
-    return process.env
+    return Object.assign({}, process.env)
   },
 
   version () {
@@ -123,9 +105,5 @@ export default {
       locator: locator,
       environment: this.getEnvironment.bind(this)
     }
-  },
-
-  consumeEnvironment (environment) {
-    this.environment = environment
   }
 }

--- a/lib/pathhelper.js
+++ b/lib/pathhelper.js
@@ -2,7 +2,6 @@
 
 import path from 'path'
 import os from 'os'
-import osHomedir from 'os-homedir'
 import {isFalsy} from './check'
 
 function expand (env, thepath) {
@@ -64,7 +63,7 @@ function resolveAndNormalize (pathitem) {
 }
 
 function home () {
-  return osHomedir()
+  return os.homedir()
 }
 
 export default { expand, resolveAndNormalize, home }

--- a/package.json
+++ b/package.json
@@ -21,24 +21,19 @@
     "url": "https://github.com/joefitzgerald/go-config/issues"
   },
   "dependencies": {
-    "atom-package-deps": "4.0.1",
-    "fs-plus": "^2.8.2",
-    "lodash": "^4.12.0",
-    "os-homedir": "^1.0.1",
-    "semver": "^5.1.0"
+    "fs-plus": "^2.9.1",
+    "lodash": "^4.13.1",
+    "semver": "^5.2.0"
   },
   "devDependencies": {
     "fs-extra": "^0.30.0",
-    "eslint": "^2.9.0",
-    "babel-eslint": "^6.0.4",
+    "eslint": "v2.13.1",
+    "babel-eslint": "^6.1.0",
     "eslint-config-standard": "^5.3.1",
     "eslint-plugin-standard": "^1.3.2",
-    "eslint-plugin-promise": "^1.1.0",
+    "eslint-plugin-promise": "^1.3.2",
     "temp": "^0.8.3"
   },
-  "package-deps": [
-    "environment"
-  ],
   "providedServices": {
     "go-config": {
       "versions": {
@@ -47,11 +42,6 @@
       }
     }
   },
-  "consumedServices": {
-    "environment": {
-      "versions": {
-        "0.1.0": "consumeEnvironment"
-      }
   "configSchema": {
     "gopath": {
       "title": "GOPATH",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,15 @@
       "versions": {
         "0.1.0": "consumeEnvironment"
       }
+  "configSchema": {
+    "gopath": {
+      "title": "GOPATH",
+      "description": "(Not Recommended For Use) If you have issues setting your GOPATH in your environment, you can use this to establish a fallback value. See https://github.com/joefitzgerald/go-config/wiki/GOPATH for more information.",
+      "type": "string",
+      "default": "",
+      "order": 1
     }
   },
-  "configSchema": {},
   "standard": {
     "globals": [
       "atom",

--- a/spec/locator-spec.js
+++ b/spec/locator-spec.js
@@ -117,6 +117,28 @@ describe('Locator', () => {
       expect(locator.gopath).toBeDefined()
       expect(locator.gopath()).toBe(path.join(pathhelper.home(), 'go'))
     })
+
+    describe('when there is atom config for go-config.gopath', () => {
+      beforeEach(() => {
+        atom.config.set('go-config.gopath', '~/go2')
+      })
+
+      it('gopath() prioritizes the environment over the config', () => {
+        expect(locator.gopath).toBeDefined()
+        expect(locator.gopath()).toBe(path.join(pathhelper.home(), 'go'))
+      })
+    })
+
+    describe('when there is atom config for go-plus.gopath', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.gopath', '~/go2')
+      })
+
+      it('gopath() prioritizes the environment over the config', () => {
+        expect(locator.gopath).toBeDefined()
+        expect(locator.gopath()).toBe(path.join(pathhelper.home(), 'go'))
+      })
+    })
   })
 
   describe('when the environment has an empty GOPATH', () => {
@@ -130,6 +152,28 @@ describe('Locator', () => {
       expect(locator.gopath).toBeDefined()
       expect(locator.gopath()).toBe(false)
     })
+
+    describe('when there is atom config for go-config.gopath', () => {
+      beforeEach(() => {
+        atom.config.set('go-config.gopath', '~/go')
+      })
+
+      it('gopath() returns the expanded value for ~/go', () => {
+        expect(locator.gopath).toBeDefined()
+        expect(locator.gopath()).toBe(path.join(pathhelper.home(), 'go'))
+      })
+    })
+
+    describe('when there is atom config for go-plus.gopath', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.gopath', '~/go')
+      })
+
+      it('gopath() returns the expanded value for ~/go', () => {
+        expect(locator.gopath).toBeDefined()
+        expect(locator.gopath()).toBe(path.join(pathhelper.home(), 'go'))
+      })
+    })
   })
 
   describe('when the environment has a GOPATH that is whitespace', () => {
@@ -140,6 +184,28 @@ describe('Locator', () => {
     it('gopath() returns false', () => {
       expect(locator.gopath).toBeDefined()
       expect(locator.gopath()).toBe(false)
+    })
+
+    describe('when there is atom config for go-config.gopath', () => {
+      beforeEach(() => {
+        atom.config.set('go-config.gopath', '~/go')
+      })
+
+      it('gopath() returns the expanded value for ~/go', () => {
+        expect(locator.gopath).toBeDefined()
+        expect(locator.gopath()).toBe(path.join(pathhelper.home(), 'go'))
+      })
+    })
+
+    describe('when there is atom config for go-plus.gopath', () => {
+      beforeEach(() => {
+        atom.config.set('go-plus.gopath', '~/go')
+      })
+
+      it('gopath() returns the expanded value for ~/go', () => {
+        expect(locator.gopath).toBeDefined()
+        expect(locator.gopath()).toBe(path.join(pathhelper.home(), 'go'))
+      })
     })
   })
 

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -1,8 +1,6 @@
 'use babel'
 /* eslint-env jasmine */
 
-import semver from 'semver'
-
 describe('go-config', () => {
   let goconfigMain = null
 
@@ -29,15 +27,12 @@ describe('go-config', () => {
       expect(goconfigMain).toBeDefined()
       expect(goconfigMain.subscriptions).toBeDefined()
       expect(goconfigMain.subscriptions).toBeTruthy()
-      expect(goconfigMain.environment).toBeDefined()
-      expect(goconfigMain.environment).toBeTruthy()
       goconfigMain.getLocator()
       expect(goconfigMain.locator).toBeDefined()
       expect(goconfigMain.locator).toBeTruthy()
 
       goconfigMain.dispose()
       expect(goconfigMain.subscriptions).toBeFalsy()
-      expect(goconfigMain.environment).toBeFalsy()
       expect(goconfigMain.locator).toBeFalsy()
 
       goconfigMain.activate()
@@ -73,41 +68,7 @@ describe('go-config', () => {
       expect(provider.locator.gopath).toBeDefined()
       expect(provider.locator.findTool).toBeDefined()
       expect(provider.locator.runtimeCandidates).not.toBeDefined()
-      expect(provider.environment).toBeDefined()
       expect(provider.environment()).toBeTruthy()
-    })
-  })
-
-  describe('when the environment is not available', () => {
-    let e = null
-    beforeEach(() => {
-      e = goconfigMain.environment
-      goconfigMain.environment = null
-    })
-    afterEach(() => {
-      goconfigMain.environment = e
-    })
-
-    it('is not ready for Atom < 1.7.0', () => {
-      expect(goconfigMain.ready).toBeDefined()
-      if (semver.satisfies(semver.major(atom.appVersion) + '.' + semver.minor(atom.appVersion) + '.' + semver.patch(atom.appVersion), '<1.7.0')) {
-        expect(goconfigMain.ready()).toBe(false)
-      }
-    })
-
-    it('returns the process environment', () => {
-      expect(goconfigMain.environment).toBeFalsy()
-      expect(goconfigMain.getEnvironment).toBeDefined()
-      expect(goconfigMain.getEnvironment()).toBeTruthy()
-      expect(goconfigMain.getEnvironment()).toBe(process.env)
-    })
-
-    it('consumes an environment', () => {
-      expect(goconfigMain.environment).toBeFalsy()
-      goconfigMain.consumeEnvironment({PING: 'PONG'})
-      expect(goconfigMain.environment).toBeTruthy()
-      expect(goconfigMain.environment.PING).toBe('PONG')
-      expect(goconfigMain.environment.PONG).not.toBeDefined()
     })
   })
 })


### PR DESCRIPTION
This PR allows a fallback to be configured in atom configuration for `go-config`. If a GOPATH value is set in the environment, it will win. Per-project configuration will be added shortly, via https://github.com/joefitzgerald/go-config/wiki/.go-Project-Configuration-File-Format (which will help GB users out).

- Fixes #36 (thanks for the contribution @pariz !)
- Fixes #42 (thanks for the contribution @remexre !)
- Fixes https://github.com/joefitzgerald/go-plus/issues/440
- Fixes https://github.com/joefitzgerald/go-plus/issues/424
- Fixes https://github.com/joefitzgerald/go-plus/issues/423
- Fixes https://github.com/joefitzgerald/go-plus/issues/382 when used with https://atom.io/packages/project-manager
- Partially fixes https://github.com/joefitzgerald/go-plus/issues/422 